### PR TITLE
Changed Apache Service Name

### DIFF
--- a/manifests/apache2.pp
+++ b/manifests/apache2.pp
@@ -1,6 +1,9 @@
 class php::apache2($apache2_ini_content = undef, $apache2_ini_source = undef) {
     require apache
-    include php, php::apache2::install, php::apache2::config
 
-    Class["php::config"] ~> Service["apache"]
+    include php
+    include php::apache2::install
+    include php::apache2::config
+
+    Class["php::config"] ~> Service[$php::params::apache_service_name]
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class php::params {
             $apache_dir = "${base_dir}apache2/"
             $apache_ini = "${apache_dir}php.ini"
             $apache_package_name = "libapache2-mod-php5"
-            $apache_service_name = "apache2"
+            $apache_service_name = "httpd"
         }
     }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class php::params {
-    case $operatingsystem {
-        /(Ubuntu|Debian)/: {
+    case $::operatingsystem {
+        'ubuntu', 'debian': {
             $base_dir = "/etc/php5/"
             $cli_dir = "${base_dir}cli/"
             $cli_ini = "${cli_dir}php.ini"
@@ -16,7 +16,7 @@ class php::params {
             $apache_dir = "${base_dir}apache2/"
             $apache_ini = "${apache_dir}php.ini"
             $apache_package_name = "libapache2-mod-php5"
-            $apache_service_name = "httpd"
+            $apache_service_name = "apache2"
         }
     }
 }


### PR DESCRIPTION
Previously it was dynamically setting `apache2` and referencing `apache` with a hardcoded value.
