### PR TITLE
Update manifests/module.pp

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -30,7 +30,7 @@ define php::module($ensure = present, $source = undef, $content = undef, $requir
                 "puppet:///files/${domain}/etc/php5/conf.d/${file_name}",
                 "puppet:///files/global/etc/php5/conf.d/${file_name}",
             ], 
-            default => "${source}${file_name}",
+            default => $source,
         },
         content => $content ? {
             undef   => undef,


### PR DESCRIPTION
Remove obscurity of $source declaration for modules.
We can surely add the previous behavior as an append if needed, but I found myself forced to read the source code to understand how it works.
Also, this code is incompatible with possibilities, like multiple folder/file choices, so I consider that this native "feature" should be removed.
Here is my example use case:

```
php::module { 'php-apc':
    name           => 'apc',
    package_prefix => 'php-',
    notify         => Class['php::fpm::service'],
    source         => [
        "puppet:///modules/project/php/conf.d/apc.${env}.ini",
        "puppet:///modules/project/php/conf.d/apc.ini",
    ],
}
```
