### PR TITLE
Update manifests/conf.pp

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -24,7 +24,7 @@ define php::conf($ensure = present, $source = undef, $content = undef, $require 
                 "puppet:///files/${domain}/etc/php5/conf.d/${file_name}",
                 "puppet:///files/global/etc/php5/conf.d/${file_name}",
             ],
-            default => "${source}${file_name}",
+            default => $source,
         },
         content => $content ? {
             undef   => undef,


### PR DESCRIPTION
Remove obscurity of $source declaration for conf.
This follows the same previously submitted PR for modules. It allows multiple folder/file choices, so I consider that this native "feature" should be removed.
Here is my example use case:

```
php::conf { 'pdo':
    source => [
        "puppet:///modules/app/php/conf.d/pdo.${::env}.ini",
        "puppet:///modules/app/php/conf.d/pdo.ini",
    ]
}
```
